### PR TITLE
Add support for request body

### DIFF
--- a/args.go
+++ b/args.go
@@ -41,6 +41,7 @@ func (s saveStatusArgs) Includes(search int) bool {
 }
 
 type config struct {
+	body           string
 	concurrency    int
 	delay          int
 	headers        headerArgs
@@ -59,6 +60,11 @@ type config struct {
 }
 
 func processArgs() config {
+
+	// body param
+	body := ""
+	flag.StringVar(&body, "body", "", "")
+	flag.StringVar(&body, "b", "", "")
 
 	// concurrency param
 	concurrency := 20
@@ -136,6 +142,7 @@ func processArgs() config {
 	}
 
 	return config{
+		body:           body,
 		concurrency:    concurrency,
 		delay:          delay,
 		headers:        headers,
@@ -160,6 +167,7 @@ func init() {
 		h += "  meg [path|pathsFile] [hostsFile] [outputDir]\n\n"
 
 		h += "Options:\n"
+		h += "  -b, --body <val>           Set the request body\n"
 		h += "  -c, --concurrency <val>    Set the concurrency level (default: 20)\n"
 		h += "  -d, --delay <millis>       Milliseconds between requests to the same host (default: 5000)\n"
 		h += "  -H, --header <header>      Send a custom HTTP header\n"

--- a/gohttp.go
+++ b/gohttp.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/tls"
 	"fmt"
 	"io/ioutil"
@@ -33,7 +34,14 @@ func goRequest(r request) response {
 		}
 	}
 
-	req, err := http.NewRequest(r.method, r.URL(), nil)
+	var req *http.Request
+	var err error
+	if r.body != "" {
+		req, err = http.NewRequest(r.method, r.URL(), bytes.NewBuffer([]byte(r.body)))
+	} else {
+		req, err = http.NewRequest(r.method, r.URL(), nil)
+	}
+
 	if err != nil {
 		return response{request: r, err: err}
 	}

--- a/main.go
+++ b/main.go
@@ -132,6 +132,7 @@ func main() {
 				path:           prefixedPath,
 				headers:        c.headers,
 				followLocation: c.followLocation,
+				body:           c.body,
 				timeout:        time.Duration(c.timeout * 1000000),
 			}
 		}

--- a/rawhttp.go
+++ b/rawhttp.go
@@ -33,6 +33,14 @@ func rawRequest(r request) response {
 		req.AddHeader(h)
 	}
 
+	if r.body != "" {
+		req.Body = r.body
+	}
+
+	if !r.HasHeader("Content-Length") {
+		req.AutoSetContentLength()
+	}
+
 	resp, err := rawhttp.Do(req)
 	if err != nil {
 		return response{request: r, err: err}

--- a/request.go
+++ b/request.go
@@ -12,6 +12,7 @@ type request struct {
 	path    string
 	host    string
 	headers []string
+	body    string
 
 	followLocation bool
 	timeout        time.Duration


### PR DESCRIPTION
Adds support for HTTP request bodies (currently via a new `--body` argument) for both gohttp and rawhttp. Fixes #13.