### PR TITLE
meg + gf = megf enhancement

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -142,6 +142,7 @@ Options:
   -s, --savestatus <status>  Save only responses with specific status code
   -v, --verbose              Verbose mode
   -X, --method <method>      HTTP method (default: GET)
+  -g, --saveGrep <string>    Save only if grep string in response
 
 Defaults:
   pathsFile: ./paths

--- a/README.mkd
+++ b/README.mkd
@@ -142,7 +142,7 @@ Options:
   -s, --savestatus <status>  Save only responses with specific status code
   -v, --verbose              Verbose mode
   -X, --method <method>      HTTP method (default: GET)
-  -g, --saveGrep <string>    Save only if grep string in response
+  -g, --savegf <gf entry>    Save only if gf finds something
 
 Defaults:
   pathsFile: ./paths

--- a/args.go
+++ b/args.go
@@ -47,6 +47,7 @@ type config struct {
 	headers        headerArgs
 	followLocation bool
 	method         string
+	saveGrep       string
 	saveStatus     saveStatusArgs
 	timeout        int
 	verbose        bool
@@ -90,6 +91,11 @@ func processArgs() config {
 	method := "GET"
 	flag.StringVar(&method, "method", "GET", "")
 	flag.StringVar(&method, "X", "GET", "")
+
+	// saveGrep param
+	saveGrep := ""
+	flag.StringVar(&saveGrep, "saveGrep", "", "")
+	flag.StringVar(&saveGrep, "g", "", "")
 
 	// savestatus params
 	var saveStatus saveStatusArgs
@@ -148,6 +154,7 @@ func processArgs() config {
 		headers:        headers,
 		followLocation: followLocation,
 		method:         method,
+		saveGrep:       saveGrep,
 		saveStatus:     saveStatus,
 		timeout:        timeout,
 		requester:      requesterFn,
@@ -177,6 +184,7 @@ func init() {
 		h += "  -t, --timeout <millis>     Set the HTTP timeout (default: 10000)\n"
 		h += "  -v, --verbose              Verbose mode\n"
 		h += "  -X, --method <method>      HTTP method (default: GET)\n\n"
+		h += "  -g, --saveGrep <string>    Save only if grep string in response\n\n"
 
 		h += "Defaults:\n"
 		h += "  pathsFile: ./paths\n"

--- a/args.go
+++ b/args.go
@@ -47,7 +47,7 @@ type config struct {
 	headers        headerArgs
 	followLocation bool
 	method         string
-	saveGrep       string
+	savegf         string
 	saveStatus     saveStatusArgs
 	timeout        int
 	verbose        bool
@@ -92,10 +92,10 @@ func processArgs() config {
 	flag.StringVar(&method, "method", "GET", "")
 	flag.StringVar(&method, "X", "GET", "")
 
-	// saveGrep param
-	saveGrep := ""
-	flag.StringVar(&saveGrep, "saveGrep", "", "")
-	flag.StringVar(&saveGrep, "g", "", "")
+	// savegf param
+	savegf := ""
+	flag.StringVar(&savegf, "savegf", "", "")
+	flag.StringVar(&savegf, "g", "", "")
 
 	// savestatus params
 	var saveStatus saveStatusArgs
@@ -154,7 +154,7 @@ func processArgs() config {
 		headers:        headers,
 		followLocation: followLocation,
 		method:         method,
-		saveGrep:       saveGrep,
+		savegf:         savegf,
 		saveStatus:     saveStatus,
 		timeout:        timeout,
 		requester:      requesterFn,
@@ -184,7 +184,7 @@ func init() {
 		h += "  -t, --timeout <millis>     Set the HTTP timeout (default: 10000)\n"
 		h += "  -v, --verbose              Verbose mode\n"
 		h += "  -X, --method <method>      HTTP method (default: GET)\n\n"
-		h += "  -g, --saveGrep <string>    Save only if grep string in response\n\n"
+		h += "  -g, --savegf <gf entry>    Save only if gf finds something\n\n"
 
 		h += "Defaults:\n"
 		h += "  pathsFile: ./paths\n"

--- a/main.go
+++ b/main.go
@@ -97,9 +97,9 @@ func main() {
 			}
 
 			path, err := res.save(c.output, c.noHeaders)
-			if len(c.saveGrep) > 0 {
+			if len(c.savegf) > 0 {
 				var cmd *exec.Cmd
-				cmd = exec.Command("grep", "--color", c.saveGrep, path)
+				cmd = exec.Command("gf", c.savegf, path)
 				var out bytes.Buffer
 				cmd.Stdout = &out
 				cmd.Stderr = os.Stderr


### PR DESCRIPTION
I added a switch which will allow meg to only save the file if the gf expressions finds a hit. This is really useful if you're looking for a specific thing across a very large data set. Or if you're looking for something in the index or js files of many sites. It removes almost all false positives. 

flag:
-g <gf expression>

example:
put this xml.json in ~/.gf:
```{
    "flags": "-Hnri",
    "pattern": "xml version"
}```  

and then run:
`meg -s 200 -g xml /web.config`

It won't save off all those fake 200s.