### PR TITLE
Adds a prefix into the path

### DIFF
--- a/args.go
+++ b/args.go
@@ -49,6 +49,7 @@ type config struct {
 	method         string
 	saveStatus     saveStatusArgs
 	timeout        int
+	prefix         string
 	verbose        bool
 
 	paths     string
@@ -115,6 +116,11 @@ func processArgs() config {
 	flag.BoolVar(&verbose, "verbose", false, "")
 	flag.BoolVar(&verbose, "v", false, "")
 
+	// prefix param
+	prefix := ""
+	flag.StringVar(&prefix, "prefix", "", "")
+	flag.StringVar(&prefix, "p", "", "")
+
 	flag.Parse()
 
 	// paths might be in a file, or it might be a single value
@@ -152,6 +158,7 @@ func processArgs() config {
 		timeout:        timeout,
 		requester:      requesterFn,
 		verbose:        verbose,
+		prefix:         prefix,
 		paths:          paths,
 		hosts:          hosts,
 		output:         output,
@@ -172,6 +179,7 @@ func init() {
 		h += "  -d, --delay <millis>       Milliseconds between requests to the same host (default: 5000)\n"
 		h += "  -H, --header <header>      Send a custom HTTP header\n"
 		h += "  -L, --location             Follow redirects / location header\n"
+		h += "  -p, --prefix               Add a prefix to each path\n"
 		h += "  -r, --rawhttp              Use the rawhttp library for requests (experimental)\n"
 		h += "  -s, --savestatus <status>  Save only responses with specific status code\n"
 		h += "  -t, --timeout <millis>     Set the HTTP timeout (default: 10000)\n"

--- a/main.go
+++ b/main.go
@@ -119,7 +119,7 @@ func main() {
 				fmt.Fprintf(os.Stderr, "failed to parse host: %s\n", err)
 				continue
 			}
-			prefixedPath := u.Path + path
+			prefixedPath := u.Path + c.prefix + path
 			u.Path = ""
 
 			// stripping off a path means we need to


### PR DESCRIPTION
Hi, @tomnomnom hope you're doing well.

What do you think about this addition? Let me explain the scenario.

I'm using **meg** with a different wordlist. I'm combining the wordlist from [dirsearch](https://github.com/maurosoria/dirsearch) with the benefits of meg's runtime.

Since your wordlist assumes each path should start with an "/", I'm having problems doing the request in the way that I want.

So I'm thinking, why if **meg** supports a prefix flag that should be appended dynamically to each path before to send the request? So I don't need to edit my wordlist and we make **meg** more adaptable to a different source.

Tested and works perfectly:
```
meg -v -p / hosts.txt paths.txt output
```

Let me know your thoughts.
Ronny