### PR TITLE
Added JSON output

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -244,3 +244,17 @@ out/example.com/61ac5fbb9d3dd054006ae82630b045ba730d8618:3:> TRACE /robots.txt H
 out/example.com/bd8d9f4c470ffa0e6ec8cfa8ba1c51d62289b6dd:3:> TRACE /.well-known/security.txt HTTP/1.1
 ...
 ```
+
+### JSON Output
+
+Instead of the usual meg output it is also possible to output the results
+as a JSON string with the `-j` or `--jsonOut` option:
+
+```
+▶ meg --jsonOut
+{"request":{"url":"","hostname":"","method":"","path":"","host":"","headers":[{"headerkey":"","headervalue":""},{"headerkey":"","headervalue":""}],"body":"","follow":false},"response":{"statuscode":,"status":"","headers":[{"headerkey":"","headervalue":""}],"body":""}}
+```
+
+### No headers
+
+With --no-headers you suppress the output of HTTP headers.

--- a/args.go
+++ b/args.go
@@ -50,7 +50,7 @@ type config struct {
 	saveStatus     saveStatusArgs
 	timeout        int
 	verbose        bool
-	jsonOut		   bool
+	jsonOut        bool
 
 	paths     string
 	hosts     string
@@ -162,7 +162,7 @@ func processArgs() config {
 		hosts:          hosts,
 		output:         output,
 		noHeaders:      noHeaders,
-		jsonOut:		jsonOut,
+		jsonOut:        jsonOut,
 	}
 }
 
@@ -184,7 +184,7 @@ func init() {
 		h += "  -t, --timeout <millis>     Set the HTTP timeout (default: 10000)\n"
 		h += "  -v, --verbose              Verbose mode\n"
 		h += "  -X, --method <method>      HTTP method (default: GET)\n"
-		h += "      --no-header            Don't output headers\n"
+		h += "      --no-headers            Don't output headers\n"
 		h += "  -j, --jsonOut              Output in JSON\n\n"
 
 		h += "Defaults:\n"

--- a/args.go
+++ b/args.go
@@ -50,6 +50,7 @@ type config struct {
 	saveStatus     saveStatusArgs
 	timeout        int
 	verbose        bool
+	jsonOut		   bool
 
 	paths     string
 	hosts     string
@@ -106,6 +107,11 @@ func processArgs() config {
 	flag.BoolVar(&rawHTTP, "rawhttp", false, "")
 	flag.BoolVar(&rawHTTP, "r", false, "")
 
+	// Json Output param
+	jsonOut := false
+	flag.BoolVar(&jsonOut, "jsonOut", false, "")
+	flag.BoolVar(&jsonOut, "j", false, "")
+
 	// no headers
 	noHeaders := false
 	flag.BoolVar(&noHeaders, "no-headers", false, "")
@@ -156,6 +162,7 @@ func processArgs() config {
 		hosts:          hosts,
 		output:         output,
 		noHeaders:      noHeaders,
+		jsonOut:		jsonOut,
 	}
 }
 
@@ -176,7 +183,9 @@ func init() {
 		h += "  -s, --savestatus <status>  Save only responses with specific status code\n"
 		h += "  -t, --timeout <millis>     Set the HTTP timeout (default: 10000)\n"
 		h += "  -v, --verbose              Verbose mode\n"
-		h += "  -X, --method <method>      HTTP method (default: GET)\n\n"
+		h += "  -X, --method <method>      HTTP method (default: GET)\n"
+		h += "      --no-header            Don't output headers\n"
+		h += "  -j, --jsonOut              Output in JSON\n\n"
 
 		h += "Defaults:\n"
 		h += "  pathsFile: ./paths\n"

--- a/main.go
+++ b/main.go
@@ -93,7 +93,7 @@ func main() {
 				continue
 			}
 
-			path, err := res.save(c.output, c.noHeaders)
+			path, err := res.save(c.output, c.noHeaders, c.jsonOut)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "failed to save file: %s\n", err)
 			}

--- a/response.go
+++ b/response.go
@@ -7,6 +7,8 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"encoding/json"
+	"strings"
 )
 
 // a response is a wrapper around an HTTP response;
@@ -22,7 +24,121 @@ type response struct {
 }
 
 // String returns a string representation of the request and response
-func (r response) String() string {
+func (r response) jsonString(noHeaders bool) string {
+	if noHeaders{
+		// Falsch TODO
+		b := &bytes.Buffer{}
+		b.Write(r.body)
+		return b.String()
+	}
+
+	b := &bytes.Buffer{}
+
+	b.WriteString(r.request.URL())
+	b.WriteString("\n\n")
+
+	b.WriteString(fmt.Sprintf("%s %s HTTP/1.1\n", r.request.method, r.request.path))
+
+	// request headers
+	for _, h := range r.request.headers {
+		b.WriteString(fmt.Sprintf("%s\n", h))
+	}
+	b.WriteString("\n")
+
+	// status line
+	b.WriteString(fmt.Sprintf("HTTP/1.1 %s\n", r.status))
+
+	// response headers
+	for _, h := range r.headers {
+		b.WriteString(fmt.Sprintf("%s\n", h))
+	}
+	b.WriteString("\n")
+
+	// body
+	/*
+	r.headers
+	r.status
+	r.err
+	*/
+	type JsonHeader struct{
+		JsonHeaderKey string `json:"headerkey"`
+		JsonHeaderValue string `json:"headervalue"`
+	}
+	type JsonRequest struct {
+		JsonRequestUrl string `json:"url"`
+		JsonRequestHostname string `json:"hostname"`
+		JsonRequestMethod string `json:"method"`
+		JsonRequestPath    string `json:"path"`
+		JsonRequestHost    string `json:"host"`
+		JsonRequestHeaders    []JsonHeader `json:"headers"`
+		JsonRequestBody    string `json:"body"`
+		JsonRequestFollow    bool `json:"follow"`
+	}
+	r.request.Hostname()
+	type JsonResponse struct {
+		JsonResponseStatusCode    int `json:"statuscode"`
+		JsonResponseStatus    string `json:"status"`
+		JsonResponseHeader    []JsonHeader `json:"headers"`
+		JsonBody    string `json:"body"`
+	}
+	type JsonOut struct {
+		JsonRequest JsonRequest `json:"request"`
+		JsonResponse JsonResponse `json:"response"`
+	}
+	var jsonRequestHeaders []JsonHeader
+	for _, h := range r.request.headers {
+		x := strings.Split(h, ":")
+		jsonRequestHeaders = append(jsonRequestHeaders, JsonHeader{x[0], strings.TrimSpace(x[1])})
+	}
+	var jsonResponseHeaders []JsonHeader
+	for _, h := range r.headers {
+		x := strings.Split(h, ":")
+		jsonResponseHeaders = append(jsonResponseHeaders, JsonHeader{x[0], strings.TrimSpace(x[1])})
+	}
+	//r.h
+	//	var jsonRequestHeader []JsonHeader
+	//	for _, h := range r.request.headers {
+	//		x := strings.Split(h, ":")
+	//		jsonRequestHeader = append(jsonRequestHeader, JsonHeader{x[0], strings.TrimSpace(x[1])})
+	//	}
+	//	//r.headers
+	x := &bytes.Buffer{}
+	x.Write(r.body)
+	x.String()
+	resp := JsonOut{
+		JsonRequest{
+			r.request.URL(),
+			r.request.Hostname(),
+			r.request.method,
+			r.request.path,
+			r.request.host,
+			jsonRequestHeaders,
+			r.request.body,
+			r.request.followLocation,
+			},
+			JsonResponse{
+				r.statusCode,
+				r.status,
+				jsonResponseHeaders,
+				x.String(),
+			},
+	}
+	ba, err := json.Marshal(resp)
+	if err != nil {
+		fmt.Println("error:", err)
+	}
+	fmt.Printf("%s", ba)
+	return b.String()
+}
+
+// String returns a string representation of the request and response
+func (r response) megString(noHeaders bool) string {
+	if noHeaders{
+		b := &bytes.Buffer{}
+		b.Write(r.body)
+		return b.String()
+	}
+
 	b := &bytes.Buffer{}
 
 	b.WriteString(r.request.URL())
@@ -51,22 +167,21 @@ func (r response) String() string {
 	return b.String()
 }
 
-func (r response) StringNoHeaders() string {
-	b := &bytes.Buffer{}
-
-	b.Write(r.body)
-
-	return b.String()
-}
 
 // save write a request and response output to disk
-func (r response) save(pathPrefix string, noHeaders bool) (string, error) {
+func (r response) save(pathPrefix string, noHeaders bool, json bool) (string, error) {
+	var content []byte
 
-	content := []byte(r.String())
+	if json{
+		content = []byte(r.jsonString(noHeaders))
+	}else{
+		content = []byte(r.megString(noHeaders))
+	}
+/*
 	if noHeaders {
 		content = []byte(r.StringNoHeaders())
 	}
-
+*/
 	checksum := sha1.Sum(content)
 	parts := []string{pathPrefix}
 

--- a/response.go
+++ b/response.go
@@ -64,12 +64,13 @@ func (r response) jsonString(noHeaders bool) string {
 	if !noHeaders {
 		// Fill the request header struct
 		for _, h := range r.request.headers {
-			x := strings.Split(h, ":")
+			// We use SplitN because then we only split on the first colon occurrence
+			x := strings.SplitN(h, ":", 2)
 			jsonRequestHeaders = append(jsonRequestHeaders, JsonHeader{x[0], strings.TrimSpace(x[1])})
 		}
 		// Fill the response header struct
 		for _, h := range r.headers {
-			x := strings.Split(h, ":")
+			x := strings.SplitN(h, ":", 2)
 			jsonResponseHeaders = append(jsonResponseHeaders, JsonHeader{x[0], strings.TrimSpace(x[1])})
 		}
 	}


### PR DESCRIPTION
I added a flag for JSON output to the tool. With the flag set it saves a JSON string instead of the traditional meg output. 

I played/tested arround a bit and it should be stable (tbh I didn't test output created with --rawhttp).

The JSON structure: 
```
{
   "request":{
      "url":"",
      "hostname":"",
      "method":"",
      "path":"",
      "host":"",
      "headers":[{
         "headerkey":"",
         "headervalue":""}],
      "body":"",
      "follow":false
   },
   "response":{
      "statuscode":,
      "status":"",
      "headers":[{
         "headerkey":"",
         "headervalue":""}],
      "body":""
   }
}
```

Not much more to say about it, I guess.