### PR TITLE
Added support for tracker links in paths, and filtering responses by header

### DIFF
--- a/args.go
+++ b/args.go
@@ -41,6 +41,7 @@ func (s saveStatusArgs) Includes(search int) bool {
 }
 
 type config struct {
+	trackerLink    string
 	body           string
 	concurrency    int
 	delay          int
@@ -60,6 +61,9 @@ type config struct {
 }
 
 func processArgs() config {
+
+	trackerLink := ""
+	flag.StringVar(&trackerLink, "tracker", "", "")
 
 	// body param
 	body := ""
@@ -142,6 +146,7 @@ func processArgs() config {
 	}
 
 	return config{
+		trackerLink:    trackerLink,
 		body:           body,
 		concurrency:    concurrency,
 		delay:          delay,

--- a/args.go
+++ b/args.go
@@ -42,6 +42,7 @@ func (s saveStatusArgs) Includes(search int) bool {
 
 type config struct {
 	trackerLink    string
+	saveHeader     string
 	body           string
 	concurrency    int
 	delay          int
@@ -62,6 +63,7 @@ type config struct {
 
 func processArgs() config {
 
+	// tracker link params
 	trackerLink := ""
 	flag.StringVar(&trackerLink, "tracker", "", "")
 
@@ -99,6 +101,11 @@ func processArgs() config {
 	var saveStatus saveStatusArgs
 	flag.Var(&saveStatus, "savestatus", "")
 	flag.Var(&saveStatus, "s", "")
+
+	// saveheader parms
+	saveHeader := ""
+	flag.StringVar(&saveHeader, "saveheader", "", "")
+	flag.StringVar(&saveHeader, "sh", "", "")
 
 	// timeout param
 	timeout := 10000
@@ -147,6 +154,7 @@ func processArgs() config {
 
 	return config{
 		trackerLink:    trackerLink,
+		saveHeader:     saveHeader,
 		body:           body,
 		concurrency:    concurrency,
 		delay:          delay,
@@ -182,6 +190,8 @@ func init() {
 		h += "  -t, --timeout <millis>     Set the HTTP timeout (default: 10000)\n"
 		h += "  -v, --verbose              Verbose mode\n"
 		h += "  -X, --method <method>      HTTP method (default: GET)\n\n"
+		h += "  -tracker <tracker link>    Replaces {tracker} in paths with the specified tracker link\n"
+		h += "  -sh --saveheader <header>  Save only responses containing a specific header\n"
 
 		h += "Defaults:\n"
 		h += "  pathsFile: ./paths\n"

--- a/main.go
+++ b/main.go
@@ -89,6 +89,10 @@ func main() {
 				continue
 			}
 
+			if c.saveHeader != "" && !res.hasHeader(c.saveHeader) {
+				continue
+			}
+
 			if res.err != nil {
 				fmt.Fprintf(os.Stderr, "request failed: %s\n", res.err)
 				continue

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"sync"
 	"time"
+	"strings"
 )
 
 const (
@@ -115,10 +116,16 @@ func main() {
 			// so we should strip that off and add it to
 			// the beginning of the path.
 			u, err := url.Parse(host)
+
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "failed to parse host: %s\n", err)
 				continue
 			}
+
+			if len(c.trackerLink) > 0 {
+				path = replaceTracker(path, u.Host, c.trackerLink)
+			}
+
 			prefixedPath := u.Path + path
 			u.Path = ""
 
@@ -136,7 +143,7 @@ func main() {
 				timeout:        time.Duration(c.timeout * 1000000),
 			}
 		}
-	}
+	} 
 
 	// once all of the requests have been sent we can
 	// close the requests channel
@@ -167,6 +174,19 @@ func readLines(filename string) ([]string, error) {
 	}
 
 	return lines, sc.Err()
+}
+
+func replaceTracker(path string, host string, trackerLink string) string {
+	now := time.Now()
+	seconds := now.Unix()
+
+	host = strings.Split(host, ":")[0]
+
+	tracker := fmt.Sprintf("%d.%s.%s", seconds, host, trackerLink)
+
+	newPath := strings.Replace(path, "{tracker}", tracker, -1)
+
+	return newPath
 }
 
 // readLinesOrLiteral tries to read lines from a file, returning

--- a/response.go
+++ b/response.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strings"
 )
 
 // a response is a wrapper around an HTTP response;
@@ -88,4 +89,13 @@ func (r response) save(pathPrefix string, noHeaders bool) (string, error) {
 	}
 
 	return p, nil
+}
+
+func (r response) hasHeader(header string) bool {
+	for _, item := range r.headers {
+		if strings.TrimSpace(item) == header {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
Added support for using `{tracker}` in the paths file. When a tracker link is specified, meg will replace the `{tracker}` placeholder with the supplied link, along with some request metadata prepended to the supplied link in order to attribute callbacks. This is useful when testing for things such as SSRF, and can be used with burp collaborator. 

I also included a commit which lets you filter responses by headers, although i see someone has also submitted a PR to filter responses by regex so this may be redundant. 