### PR TITLE
Let user try own host header

### DIFF
--- a/gohttp.go
+++ b/gohttp.go
@@ -52,6 +52,12 @@ func goRequest(r request) response {
 		r.headers = append(r.headers, fmt.Sprintf("Host: %s", r.Hostname()))
 	}
 
+	// let the request use user given host header
+	hostHeader := r.GetHeader("Host")
+	if hostHeader != "" {
+		req.Host = hostHeader
+	}
+
 	if !r.HasHeader("User-Agent") {
 		r.headers = append(r.headers, fmt.Sprintf("User-Agent: %s", userAgent))
 	}

--- a/request.go
+++ b/request.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"net/url"
 	"strings"
 	"time"
@@ -49,4 +50,20 @@ func (r request) HasHeader(h string) bool {
 		}
 	}
 	return false
+}
+
+func (r request) GetHeader(h string) string {
+	var header string
+	norm := func(s string) string {
+		return strings.ToLower(strings.TrimSpace(s))
+	}
+	for _, candidate := range r.headers {
+
+		p := strings.SplitN(candidate, ":", 2)
+		if norm(p[0]) == norm(h) {
+			header := fmt.Sprintf("%s", norm(p[1]))
+			return header
+		}
+	}
+	return header
 }


### PR DESCRIPTION
This would let a user to try their own host header value in requests; currently user provided host header is used just to show up in the output. Hope this would help in host header poison testing.