### PR TITLE
Update Go installation instructions for Linux and Windows

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -34,8 +34,21 @@ type *url.URL has no field or method Hostname)
  CertPool
 ```
 
-You should either update your version of Go, or use a binary release
-for your platform.
+If you find that your current version of Go is outdated and you need to update it, the process will vary based on your operating system.
+
+For Linux users, you can update Go by running the following command in your terminal:
+
+`sudo rm -rf /usr/local/go && wget https://golang.org/dl/go1.18.1.linux-amd64.tar.gz && sudo tar -C /usr/local -xzf go1.18.1.linux-amd64.tar.gz`
+
+Make sure to replace `go1.18.1.linux-amd64.tar.gz` with the version number of the latest Go release.
+
+For Windows users, you'll need to download the latest binaries from the official Go website. Here's how:
+
+1. Visit https://golang.org/dl/ to find the latest version of Go for Windows.
+2. Download the .msi file suitable for your system (either 32-bit or 64-bit).
+3. Run the downloaded file and follow the installation prompts to update Go on your system.
+
+After updating, you can verify the installation by opening a new terminal session and running `go version` to see the updated version number.
 
 ## Basic Usage
 


### PR DESCRIPTION
This commit updates the Go installation instructions for both Linux and Windows users. For Linux, it provides a command to remove the old version, download the latest version from the official Go website, and extract it to the correct location. Users are reminded to replace the version in the command with the latest available version of Go.

For Windows users, the commit includes steps to download the latest Go binaries from the official Go website and install them. It highlights the importance of selecting the correct file for their system architecture (32-bit or 64-bit) and following the installation prompts to complete the update.

By following these updated instructions, users can ensure they have the most recent version of Go, which includes the latest features and security patches.

Remember to verify the installation by running `go version` in a new terminal session after updating.